### PR TITLE
assign None to receiver_name

### DIFF
--- a/opendrop/cli.py
+++ b/opendrop/cli.py
@@ -125,6 +125,7 @@ class AirDropCli:
             try:
                 receiver_name = client.send_discover()
             except TimeoutError:
+                receiver_name = None
                 pass
         else:
             receiver_name = None


### PR DESCRIPTION
assign None to receiver_name, which would otherwise be referenced before assignment, after a timeout:

> Exception in thread Thread-1:
> Traceback (most recent call last):
>   File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
>     self.run()
>   File "/usr/lib/python3.7/threading.py", line 865, in run
>     self._target(*self._args, **self._kwargs)
>   File "/home/pi/Repos/opendrop/opendrop/cli.py", line 131, in _send_discover
>     discoverable = receiver_name is not None
> UnboundLocalError: local variable 'receiver_name' referenced before assignment

This change fixes the problem above.

Great project!
