### PR TITLE
In case the image's EXIF does not contain the "Orientation" key

### DIFF
--- a/opendrop/util.py
+++ b/opendrop/util.py
@@ -180,7 +180,7 @@ class AirDropUtil:
             orientation = exif['Orientation']
             if orientation in angles.keys():
                 im = im.rotate(angles[orientation], expand=True)
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass  # no EXIF data available
 
         # Big image


### PR DESCRIPTION
Sometimes if the EXIF data of the image to be sent does not contain the "Orientation" key, a KeyError will be raised.

```
Traceback (most recent call last):
  File "./bin/opendrop", line 10, in <module>
    sys.exit(main())
  File "./lib/python3.6/site-packages/opendrop/cli.py", line 38, in main
    AirDropCli(sys.argv[1:])
  File "./lib/python3.6/site-packages/opendrop/cli.py", line 87, in __init__
    self.send()
  File "./lib/python3.6/site-packages/opendrop/cli.py", line 160, in send
    if not self.client.send_ask(self.file):
  File "./lib/python3.6/site-packages/opendrop/client.py", line 150, in send_ask
    icon = AirDropUtil.generate_file_icon(f.name)
  File "./lib/python3.6/site-packages/opendrop/util.py", line 180, in generate_file_icon
    orientation = exif['Orientation']
KeyError: 'Orientation'
```

Fix: I've added an except statement for the KeyError.

Great project! 🍻