### PR TITLE
Added custom Logging class

### DIFF
--- a/opendrop/cli.py
+++ b/opendrop/cli.py
@@ -19,17 +19,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import argparse
 import json
-import logging
 import os
 import sys
 import threading
 import time
+import logging
 
 from .client import AirDropBrowser, AirDropClient
 from .config import AirDropConfig, AirDropReceiverFlags
 from .server import AirDropServer
+from .logger import Logging
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger(__name__)
+logger = Logging
 
 
 def main():

--- a/opendrop/client.py
+++ b/opendrop/client.py
@@ -31,8 +31,10 @@ import libarchive
 from zeroconf import IPVersion, ServiceBrowser, Zeroconf
 
 from .util import AbsArchiveWrite, AirDropUtil
+from .logger import Logging
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger(__name__)
+logger = Logging
 
 
 class AirDropBrowser:

--- a/opendrop/config.py
+++ b/opendrop/config.py
@@ -26,7 +26,10 @@ import subprocess
 
 from pkg_resources import resource_filename
 
-logger = logging.getLogger(__name__)
+from .logger import Logging
+
+# logger = logging.getLogger(__name__)
+logger = Logging
 
 
 class AirDropReceiverFlags:

--- a/opendrop/logger.py
+++ b/opendrop/logger.py
@@ -1,0 +1,18 @@
+import colorama
+import logging
+
+class Logging:
+    def info(message: str) -> None:
+        logging.info(message)
+        print(f"{colorama.Fore.BLUE}{colorama.Style.BRIGHT}[INFO]{colorama.Style.RESET_ALL} {message}")
+    def error(message: str) -> None:
+        logging.error(message)
+        print(f"{colorama.Fore.RED}{colorama.Style.BRIGHT}[ERROR]{colorama.Style.RESET_ALL} {message}")
+    def success(message: str) -> None:
+        print(f"{colorama.Fore.GREEN}{colorama.Style.BRIGHT}[SUCCESS]{colorama.Style.RESET_ALL} {message}")
+    def warning(message: str) -> None:
+        logging.warning(message)
+        print(f"{colorama.Fore.YELLOW}{colorama.Style.BRIGHT}[WARNING]{colorama.Style.RESET_ALL} {message}")
+    def debug(message: str) -> None:
+        logging.debug(message)
+        print(f"{colorama.Fore.MAGENTA}{colorama.Style.BRIGHT}[DEBUG]{colorama.Style.RESET_ALL} {message}")

--- a/opendrop/server.py
+++ b/opendrop/server.py
@@ -31,8 +31,10 @@ import libarchive.read
 from zeroconf import IPVersion, ServiceInfo, Zeroconf
 
 from .util import AirDropUtil
+from .logger import Logging
 
-logger = logging.getLogger(__name__)
+# logger = logging.getLogger(__name__)
+logger = Logging
 
 
 class AirDropServer:


### PR DESCRIPTION
I added a custom Logging class to fix Python's default Logging lib from not printing to the console but still logs like normal. This may log twice depending on the Python runtime so I'm going to add a way to prevent this. The logs also have colours.