### PR TITLE
Fix simple type errors

### DIFF
--- a/opendrop/cli.py
+++ b/opendrop/cli.py
@@ -219,7 +219,7 @@ class AirDropCli:
         except IndexError:
             pass
         # (2) try 'id'
-        if len(self.receiver) == 12:
+        if len(str(self.receiver)) == 12:
             for info in infos:
                 if info["id"] == self.receiver:
                     return info

--- a/opendrop/util.py
+++ b/opendrop/util.py
@@ -181,7 +181,7 @@ class AbsArchiveWrite(ArchiveWrite):
             block_size = 10240  # pragma: no cover
 
         with new_archive_entry() as entry_p:
-            entry = ArchiveEntry(None, entry_p)
+            entry = ArchiveEntry(entry_p)
             with new_archive_read_disk(path) as read_p:
                 while True:
                     r = read_next_header2(read_p, entry_p)


### PR DESCRIPTION
This PR allows devices to be targeted by ID, which previously threw an error as `len(1)` is invalid in Python 3. Also removes the `None` from creation of an ArchiveEntry, as the `self` input does not need to be passed in by the class call.