### PR TITLE
Fix startup without pkg_resources

### DIFF
--- a/opendrop/config.py
+++ b/opendrop/config.py
@@ -24,8 +24,6 @@ import socket
 import ssl
 import subprocess
 
-from pkg_resources import resource_filename
-
 logger = logging.getLogger(__name__)
 
 
@@ -104,7 +102,9 @@ class AirDropConfig:
             | AirDropReceiverFlags.SUPPORTS_DISCOVER_MAYBE
         )
 
-        self.root_ca_file = resource_filename("opendrop", "certs/apple_root_ca.pem")
+        self.root_ca_file = os.path.join(
+            os.path.dirname(__file__), "certs", "apple_root_ca.pem"
+        )
         if not os.path.exists(self.root_ca_file):
             raise FileNotFoundError(
                 f"Need Apple root CA certificate: {self.root_ca_file}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+import sys
+
+from opendrop.config import AirDropConfig
+
+
+def test_config_import_without_pkg_resources():
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.modules['pkg_resources'] = None; "
+            "from opendrop.config import AirDropConfig",
+        ],
+        check=True,
+    )
+
+
+def test_bundled_root_certificate(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = AirDropConfig(airdrop_dir=str(tmp_path / "opendrop"))
+
+    assert os.path.isfile(config.root_ca_file)
+    context = config.get_ssl_context()
+    assert context.cert_store_stats()["x509_ca"] > 0


### PR DESCRIPTION
Fixes #125.

OpenDrop now locates the bundled Apple root CA relative to its installed package, so importing the configuration and starting the CLI no longer requires `pkg_resources` or a runtime installation of setuptools. This preserves the existing filesystem certificate path and Python 3.6-compatible implementation.

Validation:
- Reproduced the original import failure in a clean Python 3.13 environment without setuptools; both new regression tests pass after the fix.
- All four tests pass with configuration directories isolated in temporary folders and the existing network tests restricted to loopback.
- Built and installed the wheel into a second clean environment: certificate loading, SSL context creation, and `opendrop --help` pass from outside the checkout.
- Black and isort checks pass for changed files. The new test passes flake8; the three existing long-line warnings in `config.py` also occur on the base revision.

Implemented and locally validated with OpenAI Codex.
